### PR TITLE
Don't track paps for pods

### DIFF
--- a/src/Jobs/FleetMembersJob.php
+++ b/src/Jobs/FleetMembersJob.php
@@ -53,6 +53,7 @@ class FleetMembersJob extends AbstractAuthCharacterJob
 
             collect($members)->each(function ($member) use ($value) {
                 $dt = carbon($member->join_time);
+                if ($member->ship_type_id != 670) {  // Do not track if its a capsule
 
                 Pap::updateOrCreate([
                     'character_id' => $member->character_id,
@@ -65,6 +66,7 @@ class FleetMembersJob extends AbstractAuthCharacterJob
                     'month' => $dt->month,
                     'year' => $dt->year,
                 ]);
+                }
             });
         } else {
             logger()->warning("No fleet found for operation $this->operation_id and fleet commander {$this->getCharacterId()}");


### PR DESCRIPTION
This change removes pap tracking for people in capsules.  The main reason here is if a fleet dies and the pap job runs (which it will), the pap log will only show people in capsules instead of what they were originally in, which is not ideal.

Also, not sure anyone ever cares to track paps for someone who is in a capsule anyway if they had never joined in a real ship to start with.